### PR TITLE
Semantic versioning

### DIFF
--- a/setup/index.txt
+++ b/setup/index.txt
@@ -9,7 +9,7 @@
 # to download and execute, type:
 # wget appleii.ivanx.com/a2server/setup; source setup
 
-a2serverVersion="127"
+a2serverVersion="1.2.7"
 
 # Ensure URL we'll use ends in a /
 case "$A2SERVER_SCRIPT_URL" in
@@ -24,8 +24,18 @@ isDebian=
 [[ ( -f /etc/debian_version ) && ( $(cut -c 1-2 < /etc/debian_version) == "7." ) && ( $(uname -m) == "i686" ) ]] && isDebian=1
 
 if [[ -f /usr/local/etc/A2SERVER-version ]]; then
+    installedVersion=$(cat /usr/local/etc/A2SERVER-version)
+    if [[ "$installedVersion" != *.*.* ]]; then
+        if [[ "$installedVersion" == [0-9][0-9][0-9] ]]; then
+            installedVersion="${installedVersion:0:1}.${installedVersion:1:1}.${installedVersion:2:1}"
+        else
+            # Whatever it is, it's not a recognized version
+            installedVersion="1.0.0"
+        fi
+    fi
     echo "A2SERVER version available: $a2serverVersion"
-    echo "A2SERVER version installed: $(cat /usr/local/etc/A2SERVER-version)"
+    echo "A2SERVER version installed: $installedVersion"
+    unset $installedVersion 2>/dev/null
 fi
 
 skipRepoUpdate=
@@ -211,10 +221,9 @@ if (( $doSetup )); then
         rm /tmp/7.console
         rm /tmp/a2server-packageReposUpdated &> /dev/null
 
-        if [[ ! -f /usr/local/etc/A2SERVER-version ]] \
-            || (( $(cat /usr/local/etc/A2SERVER-version) < "$a2serverVersion" )); then
-            echo "$a2serverVersion" | sudo tee /usr/local/etc/A2SERVER-version &> /dev/null
-        fi
+        # Running the scripts always installs this version, even if it's older than
+        # what was installed, so this file should be overwritten regardless.
+        echo "$a2serverVersion" | sudo tee /usr/local/etc/A2SERVER-version &> /dev/null
 
         source /usr/local/etc/a2server-aliases
 

--- a/update/index.txt
+++ b/update/index.txt
@@ -1,12 +1,26 @@
 #! /bin/bash
 # vim: set tabstop=4 shiftwidth=4 expandtab filetype=sh:
 
-currentVersion=127
+currentVersion="1.2.7"
 
 if [[ -f /usr/local/etc/A2SERVER-version ]]; then
     installedVersion=$(cat /usr/local/etc/A2SERVER-version)
 else
     installedVersion=100
+fi
+
+if [[ -f /usr/local/etc/A2SERVER-version ]]; then
+    installedVersion=$(cat /usr/local/etc/A2SERVER-version)
+    if [[ "$installedVersion" != *.*.* ]]; then
+        if [[ "$installedVersion" == [0-9][0-9][0-9] ]]; then
+            installedVersion="${installedVersion:0:1}.${installedVersion:1:1}.${installedVersion:2:1}"
+        else
+            # Whatever it is, it's not a recognized version
+            installedVersion="1.0.0"
+        fi
+    fi
+else
+    installedVersion="1.0.0"
 fi
 
 # Ensure URL we'll use ends in a /
@@ -27,8 +41,8 @@ echo
 echo "Update history:"
 wget -qO- "${scriptURL}update/versionhistory.txt"
 echo
-echo "installed version: ${installedVersion:0:1}.${installedVersion:1:1}.${installedVersion:2:1}"
-echo "current version: ${currentVersion:0:1}.${currentVersion:1:1}.${currentVersion:2:1}"
+echo "installed version: $installedVersion"
+echo "current version: $currentVersion"
 echo
 if [[ $autoAnswerYes ]]; then
     REPLY="y"


### PR DESCRIPTION
Closes #49.

setup/index.txt, update/index.txt: Set current version to "1.2.7".
Modified code within each to handle old (1.2.6 and older) versions
written to /usr/local/etc/A2SERVER-version.

setup/index.txt: Used to be that /usr/local/etc/A2SERVER-version was
only written if the version being installed was older than the version
already there.  That doesn't make sense given that it installs the older
version THEN starts worrying about whether the current version is older
than what was already installed.

I can and eventually will just write a version comparator and do
something about downgrades, but this doesn't seem like the time to do
it.
